### PR TITLE
Set actor affinity + windowsfix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ blog_release_note.md
 github_release_note.md
 .make-release-steps.bash
 *.swo
+/.vs
+/CMakeSettings.json

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -18,6 +18,7 @@ endmacro()
 # introductionary applications
 add(. aout)
 add(. hello_world)
+add(. affinity_example)
 
 # basic message passing primitives
 add(message_passing calculator)

--- a/examples/affinity_example.cpp
+++ b/examples/affinity_example.cpp
@@ -1,12 +1,13 @@
-#if defined(CAF_LINUX)
-#include <unistd.h>
-#endif
 
 #include <iostream>
 #include <math.h>
+#include <set>
 
 #include "caf/all.hpp"
 
+#if defined(CAF_LINUX)
+#include <unistd.h>
+#endif
 #if defined(CAF_WINDOWS)
 #include <windows.h>
 #endif
@@ -32,7 +33,7 @@ void caf_main(actor_system& system) {
   cout << "actors started" << endl;
 
 #if defined(CAF_LINUX)
-  sleep(15)
+  sleep(15);
 #elif defined(CAF_WINDOWS)
   Sleep(15000);
 #endif

--- a/examples/affinity_example.cpp
+++ b/examples/affinity_example.cpp
@@ -1,0 +1,46 @@
+#if defined(CAF_LINUX)
+#include <unistd.h>
+#endif
+
+#include <iostream>
+#include <math.h>
+
+#include "caf/all.hpp"
+
+#if defined(CAF_WINDOWS)
+#include <windows.h>
+#endif
+
+using namespace caf;
+using namespace std;
+
+void actor1(event_based_actor* self, int seconds) {
+  auto work = chrono::seconds(seconds);
+  auto start = chrono::high_resolution_clock::now();
+  do {
+    sin(1);
+  } while (chrono::high_resolution_clock::now() - start < work);
+}
+
+void caf_main(actor_system& system) {
+  cout << "CAF_VERSION=" << CAF_VERSION << endl;
+  auto& aff_manager = system.affinity_manager();
+
+  actor a1 = system.spawn<detached>(actor1, 30);
+  actor a2 = system.spawn<detached>(actor1, 30);
+
+  cout << "actors started" << endl;
+
+#if defined(CAF_LINUX)
+  sleep(15)
+#elif defined(CAF_WINDOWS)
+  Sleep(15000);
+#endif
+
+  set<int> cores{1};
+  aff_manager.set_actor_affinity(a1, cores);
+  aff_manager.set_actor_affinity(a2, cores);
+
+  cout << "actors moved" << endl;
+}
+CAF_MAIN()

--- a/libcaf_core/caf/actor.hpp
+++ b/libcaf_core/caf/actor.hpp
@@ -69,6 +69,9 @@ public:
   template <class, class, int>
   friend class actor_cast_access;
 
+  // allow affinity manager to get the underline thread
+  friend class affinity::manager;
+
   // tell actor_cast which semantic this type uses
   static constexpr bool has_weak_ptr_semantics = false;
 
@@ -190,6 +193,12 @@ public:
 private:
   inline actor_control_block* get() const noexcept {
     return ptr_.get();
+  }
+
+  // TODO: remove this and use actor_control_block
+  inline abstract_actor* gett() const noexcept {
+    CAF_ASSERT(ptr_);
+    return ptr_->get();
   }
 
   inline actor_control_block* release() noexcept {

--- a/libcaf_core/caf/affinity/affinity_manager.hpp
+++ b/libcaf_core/caf/affinity/affinity_manager.hpp
@@ -17,8 +17,7 @@
  * http://www.boost.org/LICENSE_1_0.txt.                                      *
  ******************************************************************************/
 
-#ifndef CAF_AFFINITY_MANAGER_HPP
-#define CAF_AFFINITY_MANAGER_HPP
+#pragma once
 
 #include <string>
 #include <vector>
@@ -80,6 +79,7 @@ protected:
 
     std::string getaffinityset(std::string& affinitystring);
 
+	void set_thread_affinity(int pid, std::set<int>); 
 
     std::string worker_cores_;
     std::string detached_cores_;
@@ -94,6 +94,3 @@ protected:
 
 } // namespace affinity 
 } // namespace caf
-
-
-#endif // CAF_AFFINITY_MANAGER_HPP

--- a/libcaf_core/caf/affinity/affinity_manager.hpp
+++ b/libcaf_core/caf/affinity/affinity_manager.hpp
@@ -26,6 +26,7 @@
 #include <atomic>
 
 #include "caf/actor_system.hpp"
+#include "caf/scheduled_actor.hpp"
 
 namespace caf {
 namespace affinity {
@@ -59,6 +60,8 @@ public:
     }
     
     void set_affinity(actor_system::thread_type tt); 
+
+    void set_actor_affinity(actor, std::set<int>);
 
     void start() override;
     

--- a/libcaf_core/caf/detail/private_thread.hpp
+++ b/libcaf_core/caf/detail/private_thread.hpp
@@ -21,8 +21,11 @@
 #include <atomic>
 #include <mutex>
 #include <condition_variable>
+#include <unistd.h>
+#include <syscall.h>
 
 #include "caf/fwd.hpp"
+#include "caf/config.hpp"
 
 namespace caf {
 namespace detail {
@@ -53,13 +56,25 @@ public:
 
   void start();
 
+#if defined(CAF_LINUX) || defined(CAF_BSD)
+  pid_t get_native_pid();
+#elif defined(CAF_WINDOWS)
+  HANDLE get_native_pid();
+#endif
+
 private:
+  void set_native_pid();
+
   std::mutex mtx_;
   std::condition_variable cv_;
   std::atomic<bool> self_destroyed_;
   std::atomic<scheduled_actor*> self_;
   std::atomic<worker_state> state_;
   actor_system& system_;
+  std::atomic<pid_t> native_pid_;
+#if defined(CAF_WINDOWS)
+  HANDLE native_handler_;
+#endif
 };
 
 } // namespace detail

--- a/libcaf_core/caf/detail/private_thread.hpp
+++ b/libcaf_core/caf/detail/private_thread.hpp
@@ -18,27 +18,12 @@
 
 #pragma once
 
-#ifdef CAF_LINUX
-#ifndef _GNU_SOURCE
-#define _GNU_SOURCE
-#endif // _GNU_SOURCE
-#include <unistd.h>
-#include <syscall.h>
-#endif // CAF_LINUX
-
 #include <atomic>
 #include <mutex>
 #include <condition_variable>
 
 #include "caf/fwd.hpp"
 #include "caf/config.hpp"
-
-#ifdef CAF_WINDOWS
-#ifndef WIN32_LEAN_AND_MEAN
-#define WIN32_LEAN_AND_MEAN
-#endif // WIN32_LEAN_AND_MEAN
-#include <windows.h>
-#endif // CAF_WINDOWS
 
 namespace caf {
 namespace detail {
@@ -69,11 +54,7 @@ public:
 
   void start();
 
-#if defined(CAF_LINUX) || defined(CAF_BSD)
-  pid_t get_native_pid();
-#elif defined(CAF_WINDOWS)
-  HANDLE get_native_pid();
-#endif
+  int get_native_pid();
 
 private:
   void set_native_pid();
@@ -85,11 +66,7 @@ private:
   std::atomic<worker_state> state_;
   actor_system& system_;
   std::atomic<int> native_pid_;
-#if defined(CAF_WINDOWS)
-  HANDLE native_handler_;
-#endif
 };
 
 } // namespace detail
 } // namespace caf
-

--- a/libcaf_core/caf/detail/private_thread.hpp
+++ b/libcaf_core/caf/detail/private_thread.hpp
@@ -18,14 +18,27 @@
 
 #pragma once
 
+#ifdef CAF_LINUX
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif // _GNU_SOURCE
+#include <unistd.h>
+#include <syscall.h>
+#endif // CAF_LINUX
+
 #include <atomic>
 #include <mutex>
 #include <condition_variable>
-#include <unistd.h>
-#include <syscall.h>
 
 #include "caf/fwd.hpp"
 #include "caf/config.hpp"
+
+#ifdef CAF_WINDOWS
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif // WIN32_LEAN_AND_MEAN
+#include <windows.h>
+#endif // CAF_WINDOWS
 
 namespace caf {
 namespace detail {
@@ -71,7 +84,7 @@ private:
   std::atomic<scheduled_actor*> self_;
   std::atomic<worker_state> state_;
   actor_system& system_;
-  std::atomic<pid_t> native_pid_;
+  std::atomic<int> native_pid_;
 #if defined(CAF_WINDOWS)
   HANDLE native_handler_;
 #endif

--- a/libcaf_core/caf/scheduled_actor.hpp
+++ b/libcaf_core/caf/scheduled_actor.hpp
@@ -30,6 +30,7 @@
 #include <unordered_map>
 
 #include "caf/actor_marker.hpp"
+#include "caf/affinity/affinity_manager.hpp"
 #include "caf/broadcast_downstream_manager.hpp"
 #include "caf/default_downstream_manager.hpp"
 #include "caf/error.hpp"
@@ -108,6 +109,7 @@ result<message> drop(scheduled_actor*, message_view&);
 /// A cooperatively scheduled, event-based actor implementation.
 /// @extends local_actor
 class scheduled_actor : public local_actor, public resumable {
+  friend class affinity::manager;
 public:
   // -- nested enums -----------------------------------------------------------
 

--- a/libcaf_core/src/affinity_manager.cpp
+++ b/libcaf_core/src/affinity_manager.cpp
@@ -17,13 +17,6 @@
  * http://www.boost.org/LICENSE_1_0.txt.                                      *
  ******************************************************************************/
 
-#ifdef CAF_LINUX
-#ifndef _GNU_SOURCE
-#define _GNU_SOURCE
-#endif // _GNU_SOURCE
-#include <sched.h>
-#endif // CAF_LINUX
-
 #include "caf/affinity/affinity_manager.hpp"
 
 #include <iostream>
@@ -33,6 +26,12 @@
 #include "caf/defaults.hpp"
 #include "caf/detail/private_thread.hpp"
 
+#ifdef CAF_LINUX
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif // _GNU_SOURCE
+#include <sched.h>
+#endif // CAF_LINUX
 #ifdef CAF_WINDOWS
 #ifndef WIN32_LEAN_AND_MEAN
 #define WIN32_LEAN_AND_MEAN

--- a/libcaf_core/src/affinity_manager.cpp
+++ b/libcaf_core/src/affinity_manager.cpp
@@ -23,12 +23,6 @@
 #endif // _GNU_SOURCE
 #include <sched.h>
 #endif // CAF_LINUX
-#ifdef CAF_WINDOWS
-#ifndef WIN32_LEAN_AND_MEAN
-#define WIN32_LEAN_AND_MEAN
-#endif // WIN32_LEAN_AND_MEAN
-#include <windows.h>
-#endif // CAF_WINDOWS
 
 #include "caf/affinity/affinity_manager.hpp"
 
@@ -38,6 +32,13 @@
 #include "caf/actor_system_config.hpp"
 #include "caf/defaults.hpp"
 #include "caf/detail/private_thread.hpp"
+
+#ifdef CAF_WINDOWS
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif // WIN32_LEAN_AND_MEAN
+#include <windows.h>
+#endif // CAF_WINDOWS
 
 namespace caf {
 namespace affinity {
@@ -126,7 +127,7 @@ void manager::set_actor_affinity(actor actor_handler, std::set<int> cores) {
 	// std::cout << "[DEBUG] pid: " << pid << std::endl;
   	_set_thread_affinity(pid, cores);
 #elif defined(CAF_WINDOWS)
-	_set_thread_affinity_windows(thread->get_native_pid(), cores);
+	_set_thread_affinity(thread->get_native_pid(), cores);
 #elif defined(CAF_MACOS)
 	std::cerr << "Thread affinity ignored in this platform\n";
 #else

--- a/libcaf_core/src/affinity_manager.cpp
+++ b/libcaf_core/src/affinity_manager.cpp
@@ -26,8 +26,8 @@
 
 #include "caf/affinity/affinity_manager.hpp"
 
-#include<set>
 #include <iostream>
+#include <set>
 
 #include "caf/actor_system_config.hpp"
 #include "caf/defaults.hpp"
@@ -43,218 +43,221 @@
 namespace caf {
 namespace affinity {
 
-#if defined(CAF_LINUX) || defined(CAF_BSD)
-void _set_thread_affinity(pid_t pid, std::set<int> cores){
-    if (cores.size()) {
-		// Create a cpu_set_t object representing a set of CPUs.
-		// Clear it and mark only CPU i as set.
-		cpu_set_t cpuset;
-		CPU_ZERO(&cpuset);
-		
-		for (int const& c : cores) {
-			//printf("Thread %p running on core %d\n", (void*)pthread_self(), c);
-			CPU_SET(c, &cpuset);
-			};
-		
-		if (sched_setaffinity(pid, sizeof(cpu_set_t), &cpuset)<0) {
-			//perror("sched_setaffinity");
-			std::cerr << "Error setting affinity\n";		
-		}
-	}
-}
-#elif defined(CAF_WINDOWS)
-void _set_thread_affinity(HANDLE handler, std::set<int> cores){
-	if (cores.size()) {
-	    // we do not conside the process affinity map 
-	    DWORD_PTR mask = 0;
-	    for (int const& c : cores) {
-		    mask |= (static_cast<DWORD_PTR>(1) << c);
-		  };
-		// TODO: check if this work
-	    auto ret = SetThreadAffinityMask(handler, mask);
-	    if (ret == 0) {
-			  std::cerr << "Error setting affinity\n";
-	    }
-	}
-}
-#endif
+void manager::set_thread_affinity(int pid, std::set<int> cores) {
+  // TODO: add support for FreeBSD with
+  // http://netbsd.gw.com/cgi-bin/man-cgi?pthread_setaffinity_np+3+NetBSD-current
+#if defined(CAF_LINUX)
+  if (cores.size()) {
+    // Create a cpu_set_t object representing a set of CPUs.
+    // Clear it and mark only CPU i as set.
+    cpu_set_t cpuset;
+    CPU_ZERO(&cpuset);
 
-manager::manager(actor_system& sys)
-    : system_(sys) {
-    // initialize atomics_ array
-    for(auto& a: atomics_)  
-	a.store(0);
+    for (int const& c : cores) {
+      // printf("Thread %p running on core %d\n", (void*)pthread_self(), c);
+      CPU_SET(c, &cpuset);
+    };
+
+    if (sched_setaffinity(pid, sizeof(cpu_set_t), &cpuset) < 0) {
+      // perror("sched_setaffinity");
+      std::cerr << "Error setting affinity\n";
+    }
+  }
+#elif defined(CAF_WINDOWS)
+  if (cores.size()) {
+    HANDLE thread_ptr =
+      pid != 0 ? OpenThread(THREAD_ALL_ACCESS, FALSE, pid) : GetCurrentThread();
+
+    // we do not conside the process affinity map
+    DWORD_PTR mask = 0;
+    for (int const& c : cores) {
+      mask |= (static_cast<DWORD_PTR>(1) << c);
+    };
+    // TODO: check if this work
+    auto ret = SetThreadAffinityMask(thread_ptr, mask);
+    if (ret == 0) {
+      std::cerr << "Error setting affinity\n";
+    }
+    CloseHandle(thread_ptr);
+  }
+#elif defined(CAF_MACOS)
+  std::cerr << "Thread affinity ignored in this platform\n";
+#else
+  std::cerr << "Thread affinity not supported in this platform\n";
+#endif
 }
-    
-void manager::start() {}
-void manager::stop() {}
+
+manager::manager(actor_system& sys) : system_(sys) {
+  // initialize atomics_ array
+  for (auto& a : atomics_)
+    a.store(0);
+}
+
+void manager::start() {
+}
+void manager::stop() {
+}
 
 void manager::set_affinity(const actor_system::thread_type tt) {
-    CAF_ASSERT(tt<actor_system::no_id);
-    auto  cores  =cores_[tt];
-    if (cores.size()) {
-	auto& atomics =atomics_[tt];
-	size_t id = atomics.fetch_add(1) % cores.size();
-	auto Set{cores[id]};
-	 // Set the affinity of the thread
-#if defined(CAF_LINUX) || defined(CAF_BSD)
-  	_set_thread_affinity(0, Set);
-#elif defined(CAF_WINDOWS)
-	_set_thread_affinity(GetCurrentThread(), Set);
-#elif defined(CAF_MACOS)
-	std::cerr << "Thread affinity ignored in this platform\n";
-#else
-	std::cerr << "Thread affinity not supported in this platform\n";
-#endif
-    }
+  CAF_ASSERT(tt < actor_system::no_id);
+  auto cores = cores_[tt];
+  if (cores.size()) {
+    auto& atomics = atomics_[tt];
+    size_t id = atomics.fetch_add(1) % cores.size();
+    auto Set{cores[id]};
+    // Set the affinity of the thread
+    set_thread_affinity(0, Set);
+  }
 }
 
 void manager::set_actor_affinity(actor actor_handler, std::set<int> cores) {
   // TODO: remove method .gett()
-  scheduled_actor* sched_actor = reinterpret_cast<scheduled_actor*>(actor_handler.gett());
+  scheduled_actor* sched_actor =
+    reinterpret_cast<scheduled_actor*>(actor_handler.gett());
 
   // Get the private thread if any
   detail::private_thread* thread = sched_actor->private_thread_;
   CAF_ASSERT(thread != nullptr);
   if (thread == 0) {
-    // TODO: implement errors using https://actor-framework.readthedocs.io/en/stable/Error.html
-    CAF_RAISE_ERROR("set_actor_affinity can be used only with detached actors.");
+    // TODO: implement errors using
+    // https://actor-framework.readthedocs.io/en/stable/Error.html
+    CAF_RAISE_ERROR(
+      "set_actor_affinity can be used only with detached actors.");
   }
 
   // Set the affinity of the thread
-#if defined(CAF_LINUX) || defined(CAF_BSD)
-    auto pid = thread->get_native_pid();
-	// std::cout << "[DEBUG] pid: " << pid << std::endl;
-  	_set_thread_affinity(pid, cores);
-#elif defined(CAF_WINDOWS)
-	_set_thread_affinity(thread->get_native_pid(), cores);
-#elif defined(CAF_MACOS)
-	std::cerr << "Thread affinity ignored in this platform\n";
-#else
-	std::cerr << "Thread affinity not supported in this platform\n";
-#endif
+  auto pid = thread->get_native_pid();
+  set_thread_affinity(pid, cores);
 }
 
 std::string manager::getaffinityset(std::string& affinitystring) {
-    size_t pos = affinitystring.find_first_of(SETSEPARATOR);
-    if (pos == std::string::npos) {
-	const std::string s{affinitystring};
-	affinitystring.clear();
-	return s;
-    }
-    const std::string s = affinitystring.substr(0,pos);
-    affinitystring = affinitystring.substr(pos+1);
+  size_t pos = affinitystring.find_first_of(SETSEPARATOR);
+  if (pos == std::string::npos) {
+    const std::string s{affinitystring};
+    affinitystring.clear();
     return s;
+  }
+  const std::string s = affinitystring.substr(0, pos);
+  affinitystring = affinitystring.substr(pos + 1);
+  return s;
 }
 
 std::set<int> manager::parseaffinityset(std::string s) {
-    std::set<int> Set;
-    const std::string scopy{s};
-    const std::string SEPARATOR{RANGESEPARATOR+SPACE};
-    auto checkhyphen = [](const std::string& s, int l, int r) {
-	return (s.find_first_of("-",l,r-l) != std::string::npos);
-    };
-    
-    try {
-	while(!s.empty()) {
-	    size_t pos1 = s.find_first_not_of(SPACE);
-	    if (pos1 == std::string::npos) 
-		s.clear();
-	    else {
-		size_t pos2 = s.find_first_of(SEPARATOR, pos1+1);
-		if (pos2 == std::string::npos) {
-		    int val = std::stoi(s);
-		    if (val<0) throw std::invalid_argument("negative value");
-		    Set.insert(val);
-		    s.clear();
-		} else {
-		    size_t pos3 = s.find_first_not_of(SEPARATOR, pos2+1);
-		    if ((pos3 != std::string::npos) && checkhyphen(s,pos1,pos3)) {
-			int left=std::stoi(s.substr(pos1,pos2));
-			if (left<0) throw std::invalid_argument("negative value");
-			pos2 = s.find_first_of(SEPARATOR, pos3);
-			int right = -1;
-			if (pos2 == std::string::npos) {
-			    right = std::stoi(s.substr(pos3));
-			    if (right<0) throw std::invalid_argument("negative value");
-			    s.clear();
-			}
-			else {
-			    right = std::stoi(s.substr(pos3,pos2));
-			    if (right<0) throw std::invalid_argument("negative value");
-			    s = s.substr(pos2);
-			}
-			for(int k=left;k<=right;++k) Set.insert(k);
-		    } else {
-			if (checkhyphen(s,pos1, s.length())) throw std::invalid_argument("not a range");
-			const std::string tmp=s.substr(pos1,pos2);
-			int val = std::stoi(tmp);
-			if (val<0) throw std::invalid_argument("negative value");
-			Set.insert(val);
-			s = s.substr(pos2);
-		    }
-		}
-	    }
-	}
-    } catch (std::invalid_argument& e) {
-	std::cerr << "Invalid argument into the set " << scopy << "\n";
-	return std::set<int>();
-    } catch (std::out_of_range& e) {
-	std::cerr << "Number out of range into the set " << scopy << "\n";
-	return std::set<int>();
-    }    
-    return Set;
+  std::set<int> Set;
+  const std::string scopy{s};
+  const std::string SEPARATOR{RANGESEPARATOR + SPACE};
+  auto checkhyphen = [](const std::string& s, int l, int r) {
+    return (s.find_first_of("-", l, r - l) != std::string::npos);
+  };
+
+  try {
+    while (!s.empty()) {
+      size_t pos1 = s.find_first_not_of(SPACE);
+      if (pos1 == std::string::npos)
+        s.clear();
+      else {
+        size_t pos2 = s.find_first_of(SEPARATOR, pos1 + 1);
+        if (pos2 == std::string::npos) {
+          int val = std::stoi(s);
+          if (val < 0)
+            throw std::invalid_argument("negative value");
+          Set.insert(val);
+          s.clear();
+        } else {
+          size_t pos3 = s.find_first_not_of(SEPARATOR, pos2 + 1);
+          if ((pos3 != std::string::npos) && checkhyphen(s, pos1, pos3)) {
+            int left = std::stoi(s.substr(pos1, pos2));
+            if (left < 0)
+              throw std::invalid_argument("negative value");
+            pos2 = s.find_first_of(SEPARATOR, pos3);
+            int right = -1;
+            if (pos2 == std::string::npos) {
+              right = std::stoi(s.substr(pos3));
+              if (right < 0)
+                throw std::invalid_argument("negative value");
+              s.clear();
+            } else {
+              right = std::stoi(s.substr(pos3, pos2));
+              if (right < 0)
+                throw std::invalid_argument("negative value");
+              s = s.substr(pos2);
+            }
+            for (int k = left; k <= right; ++k)
+              Set.insert(k);
+          } else {
+            if (checkhyphen(s, pos1, s.length()))
+              throw std::invalid_argument("not a range");
+            const std::string tmp = s.substr(pos1, pos2);
+            int val = std::stoi(tmp);
+            if (val < 0)
+              throw std::invalid_argument("negative value");
+            Set.insert(val);
+            s = s.substr(pos2);
+          }
+        }
+      }
+    }
+  } catch (std::invalid_argument& e) {
+    std::cerr << "Invalid argument into the set " << scopy << "\n";
+    return std::set<int>();
+  } catch (std::out_of_range& e) {
+    std::cerr << "Number out of range into the set " << scopy << "\n";
+    return std::set<int>();
+  }
+  return Set;
 }
 
 void manager::init(actor_system_config& cfg) {
-    worker_cores_   = cfg.affinity_worker_cores;
-    detached_cores_ = cfg.affinity_detached_cores;
-    blocking_cores_ = cfg.affinity_blocking_cores;
-    other_cores_    = cfg.affinity_other_cores;
+  worker_cores_ = cfg.affinity_worker_cores;
+  detached_cores_ = cfg.affinity_detached_cores;
+  blocking_cores_ = cfg.affinity_blocking_cores;
+  other_cores_ = cfg.affinity_other_cores;
 
-    auto Fill = [&](std::string copy, core_sets& c) {
-	const size_t m = c.size();
-	size_t i=0;
-	while(!copy.empty()) {
-	    std::set<int> Set = parseaffinityset(getaffinityset(copy));
-	    if (m) c[i % m].insert(Set.begin(), Set.end());
-	    else c.push_back(Set);
-	    ++i;
-	}
-	return i;
-    };
-
-	namespace sr = defaults::scheduler;
-    auto num_workers_ = get_or(cfg, "scheduler.max-threads", sr::max_threads);
-
-    // workers
-    auto& worker_cores = cores_[actor_system::worker_thread];
-    worker_cores.resize(num_workers_);
-    size_t howmany = Fill(worker_cores_, worker_cores);
-    // fill out remaining (if any)
-    if (howmany < num_workers_ && howmany>0 && worker_cores[howmany-1].size()) {
-	for(size_t k=howmany, j=0; k<num_workers_; ++k, ++j) 
-	    worker_cores[k]=worker_cores[j % howmany];	
+  auto Fill = [&](std::string copy, core_sets& c) {
+    const size_t m = c.size();
+    size_t i = 0;
+    while (!copy.empty()) {
+      std::set<int> Set = parseaffinityset(getaffinityset(copy));
+      if (m)
+        c[i % m].insert(Set.begin(), Set.end());
+      else
+        c.push_back(Set);
+      ++i;
     }
-    // private (detached thread)
-    auto& private_cores = cores_[actor_system::private_thread];
-    Fill(detached_cores_, private_cores);
-    // blocking
-    auto& blocking_cores = cores_[actor_system::blocking_thread];
-    Fill(blocking_cores_, blocking_cores);
-    // other
-    auto& other_cores = cores_[actor_system::other_thread];
-    Fill(other_cores_, other_cores);
+    return i;
+  };
+
+  namespace sr = defaults::scheduler;
+  auto num_workers_ = get_or(cfg, "scheduler.max-threads", sr::max_threads);
+
+  // workers
+  auto& worker_cores = cores_[actor_system::worker_thread];
+  worker_cores.resize(num_workers_);
+  size_t howmany = Fill(worker_cores_, worker_cores);
+  // fill out remaining (if any)
+  if (howmany < num_workers_ && howmany > 0
+      && worker_cores[howmany - 1].size()) {
+    for (size_t k = howmany, j = 0; k < num_workers_; ++k, ++j)
+      worker_cores[k] = worker_cores[j % howmany];
+  }
+  // private (detached thread)
+  auto& private_cores = cores_[actor_system::private_thread];
+  Fill(detached_cores_, private_cores);
+  // blocking
+  auto& blocking_cores = cores_[actor_system::blocking_thread];
+  Fill(blocking_cores_, blocking_cores);
+  // other
+  auto& other_cores = cores_[actor_system::other_thread];
+  Fill(other_cores_, other_cores);
 }
-    
+
 actor_system::module::id_t manager::id() const {
-    return module::affinity_manager;
+  return module::affinity_manager;
 }
 
 void* manager::subtype_ptr() {
-    return this;
+  return this;
 }
-
 
 } // namespace affinity
 } // namespace caf

--- a/libcaf_core/src/private_thread.cpp
+++ b/libcaf_core/src/private_thread.cpp
@@ -129,7 +129,7 @@ auto private_thread::get_native_pid()
   -> HANDLE
 #endif
 {
-  pid_t pid;
+  int pid;
   while ((pid = native_pid_.load(std::memory_order_relaxed)) == 0){
     // wait that the thread update the value
   }

--- a/libcaf_core/src/private_thread.cpp
+++ b/libcaf_core/src/private_thread.cpp
@@ -16,14 +16,6 @@
  * http://www.boost.org/LICENSE_1_0.txt.                                      *
  ******************************************************************************/
 
-#ifdef CAF_LINUX
-#ifndef _GNU_SOURCE
-#define _GNU_SOURCE
-#endif // _GNU_SOURCE
-#include <sys/syscall.h>
-#include <unistd.h>
-#endif // CAF_LINUX
-
 #include "caf/detail/private_thread.hpp"
 
 #include "caf/config.hpp"
@@ -31,6 +23,13 @@
 #include "caf/logger.hpp"
 #include "caf/scheduled_actor.hpp"
 
+#ifdef CAF_LINUX
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif // _GNU_SOURCE
+#include <sys/syscall.h>
+#include <unistd.h>
+#endif // CAF_LINUX
 #ifdef CAF_WINDOWS
 #include <windows.h>
 #endif // CAF_WINDOWS

--- a/libcaf_core/test/config_value.cpp
+++ b/libcaf_core/test/config_value.cpp
@@ -228,6 +228,7 @@ CAF_TEST(successful parsing) {
   CAF_CHECK_EQUAL(get<atom_value>(parse("'abc'")), atom("abc"));
   CAF_CHECK_EQUAL(get<string>(parse("\"abc\"")), "abc");
   CAF_CHECK_EQUAL(get<string>(parse("abc")), "abc");
+  CAF_CHECK_EQUAL(get<string>(parse("1abc")), "1abc"); // accept strings starting with numbers
   CAF_CHECK_EQUAL(get<li>(parse("[1, 2, 3]")), li({1, 2, 3}));
   CAF_CHECK_EQUAL(get<ls>(parse("[\"abc\", \"def\", \"ghi\"]")),
                   ls({"abc", "def", "ghi"}));
@@ -243,8 +244,6 @@ CAF_TEST(unsuccessful parsing) {
       CAF_FAIL("assumed an error but got a result");
     return std::move(x.error());
   };
-  CAF_CHECK_EQUAL(parse("10msb"), pec::trailing_character);
-  CAF_CHECK_EQUAL(parse("10foo"), pec::trailing_character);
   CAF_CHECK_EQUAL(parse("[1,"), pec::unexpected_eof);
   CAF_CHECK_EQUAL(parse("{a=,"), pec::unexpected_character);
   CAF_CHECK_EQUAL(parse("{a=1,"), pec::unexpected_eof);


### PR DESCRIPTION
Implementation of the new feature that permits to runtime set the affinity of detached actors to specific cores. Plus some code formatting.